### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   
   prototype-db:
     container_name: prototype-db
-    image: mariadb:10.4
+    image: docker.pkg.github.com/ampersandtarski/prototype-db/prototype-db
     command: ["--sql-mode=ANSI,TRADITIONAL"]
     restart: unless-stopped
     environment:


### PR DESCRIPTION
The plain maria_db image does not give the ampersand user enough right.

This already existing image does give the correct rights to the user.

Sadly, by adding this a docker-compose up will need to be preceded by a docker login to github with a personal access token.