### PR TITLE
Use init-script and plain maria-db image

### DIFF
--- a/db-init-scripts/grant-ampersand.sql
+++ b/db-init-scripts/grant-ampersand.sql
@@ -1,0 +1,1 @@
+GRANT ALL PRIVILEGES ON *.* TO 'ampersand'@'%';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   
   prototype-db:
     container_name: prototype-db
-    image: docker.pkg.github.com/ampersandtarski/prototype-db/prototype-db
+    image: mariadb:10.4
     command: ["--sql-mode=ANSI,TRADITIONAL"]
     restart: unless-stopped
     environment:
@@ -36,6 +36,7 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=true
     volumes:
       - db-data:/var/lib/mysql
+      - ./db-init-scripts:/docker-entrypoint-initdb.d # script to setup db authorization for user ampersand.
     networks:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   
   prototype-db:
     container_name: prototype-db
-    image: mariadb:10.4
+    image: docker.pkg.github.com/ampersandtarski/prototype-db/prototype-db
     command: ["--sql-mode=ANSI,TRADITIONAL"]
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Use Michiel's init-script and plain maria-db image

This way, usage of the prototype-db does not require a docker login.
Nor do we need to maintain our own dockerfile for the ampersand DB.

Note, the extension of the added file in db-init-scripts is rather
important. In an earlier attempt we had a filename with a .d extension,
which gets ignored. Similarly, when renamed as .sh it will be executed
with bash.

Interestingly, the script only gets run when the volume used to persist
the database does not exist. Moreover, that volume stores the
permissions of the DB. Hence if you have wrong code here, but a volume
that is right, you will not notice the wrong code.

The current code has been confirmed on two separate PCs, both by
clearing the volumes.
